### PR TITLE
Fix for nested renders: if rendering an element triggers more updates, catch 'em all!

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,8 +160,11 @@ function doRender() {
   if (argsToRenderInTheNextCycle.size > 0) {
     for (const args of argsToRenderInTheNextCycle) {
       if (args.element.node && args.element.node.isConnected) {
-        rerender(args.element);
+        // Dequeue the component before the render, so that if the component
+        // triggers more renders of itself they don't get no-op'd
         argsToRenderInTheNextCycle.delete(args);
+
+        rerender(args.element);
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,8 +80,11 @@ export function defineState<TState extends Record<string, any>>(
       );
 
       // concat latest updates with pending updates.
-      const argsToUpdatePlusPendingArgs = argsToRenderInTheNextCycle.concat(
-        argsListToUpdate.filter((x) => !argsToRenderInTheNextCycle.includes(x))
+      const argsToUpdatePlusPendingArgs = Array.from(
+        new Set([
+          ...Array.from(argsToRenderInTheNextCycle),
+          ...argsListToUpdate,
+        ])
       );
 
       const componentStatesAndArgs: [
@@ -131,9 +134,8 @@ export function defineState<TState extends Record<string, any>>(
         return true;
       });
 
-      argsToRenderInTheNextCycle.length = 0;
       for (const [, args] of componentsToUpdate) {
-        argsToRenderInTheNextCycle.push(args);
+        argsToRenderInTheNextCycle.add(args);
       }
 
       setTimeout(() => {
@@ -149,16 +151,19 @@ export function defineState<TState extends Record<string, any>>(
   return proxy;
 }
 
-let argsToRenderInTheNextCycle: ForgoRenderArgs[] = [];
+// We make this a Set because if rendering a component triggers another
+// forgo-state update we want to be sure we still finish updating everything we
+// had queued, plus everything the subrender enqueues
+const argsToRenderInTheNextCycle = new Set<ForgoRenderArgs>();
 
 function doRender() {
-  if (argsToRenderInTheNextCycle.length) {
+  if (argsToRenderInTheNextCycle.size > 0) {
     for (const args of argsToRenderInTheNextCycle) {
       if (args.element.node && args.element.node.isConnected) {
         rerender(args.element);
+        argsToRenderInTheNextCycle.delete(args);
       }
     }
-    argsToRenderInTheNextCycle.length = 0;
   }
 }
 


### PR DESCRIPTION
[Sandbox](https://codesandbox.io/s/forgo-state-skipping-component-kup6dk?file=/src/index.tsx)

If some component starts rerendering due to `stateA` changing, and something in its render tree alters `stateB`, forgo-state will erase its render queue while processing `stateB` and the remaining `stateA` render work won't happen.

I've seen a couple variants of this, since there are two places where forgo-state resets `argsToRenderInTheNextCycle`.

This was introduced in Forgo v2.2.0 by [this commit](https://github.com/forgojs/forgo/commit/c157d3124281f55fc843a8e6f8a98a5de4d52321). I spent a few hours debugging this today and hit my debugging-time limit without understanding why that commit introduced the bug.

Using forgo@2.1.3, forgo-state computes `componentsToUpdate` and leaves all the old work in place. Using forgo@2.2.0, forgo-state assesses most elements as not needing to be updated. This results in them being removed from the `argsToRenderInTheNextCycle` array, and the already-in-flight `stateA` `doRender()` call aborts early because what it was looping over was yanked out from under it.

This PR fixes the issue in the sandbox and in my app, but I don't feel good about it since I'm patching the symptom without understanding why forgo@2.2.0 broke the previously-working behavior.

Thoughts?