### PR TITLE
Update to new component API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,28 @@
 {
   "name": "forgo-state",
-  "version": "2.0.0-alpha.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "forgo-state",
-      "version": "2.0.0-alpha.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^16.2.14",
         "@types/mocha": "^9.1.0",
         "@types/should": "^13.0.0",
+        "@types/source-map-support": "^0.5.4",
         "esm": "^3.2.25",
         "jsdom": "^19.0.0",
         "mocha": "^9.2.2",
         "rimraf": "^3.0.2",
         "should": "^13.2.3",
+        "source-map-support": "^0.5.21",
         "typescript": "^4.6.3"
       },
       "peerDependencies": {
-        "forgo": "^4.0.0-alpha.0"
+        "forgo": "^3.2.0-alpha.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -69,6 +71,15 @@
       "dev": true,
       "dependencies": {
         "should": "*"
+      }
+    },
+    "node_modules/@types/source-map-support": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.4.tgz",
+      "integrity": "sha512-9zGujX1sOPg32XLyfgEB/0G9ZnrjthL/Iv1ZfuAjj8LEilHZEpQSQs1scpRXPhHzGYgWiLz9ldF1cI8JhL+yMw==",
+      "dev": true,
+      "dependencies": {
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -228,6 +239,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "node_modules/chalk": {
@@ -600,9 +617,9 @@
       }
     },
     "node_modules/forgo": {
-      "version": "4.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-4.0.0-alpha.0.tgz",
-      "integrity": "sha512-D8H+ise8kS3vHWZBJRnlCIEBhC0GypT2cy+1Mf2eyuF6Jo4qxyAPw85cwdVQOosADP16UzEQjzATLb4depAiJg==",
+      "version": "3.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.2.0-beta.0.tgz",
+      "integrity": "sha512-JSLvM3Xwa++R2Y09b9TIoPueITRoF0pLQuXTZWoTBZ/fBqVbrIxlaEOBF+q9YTQbE97Cxag0rC1CvWwcjevWoA==",
       "peer": true
     },
     "node_modules/form-data": {
@@ -1366,9 +1383,18 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -1847,6 +1873,15 @@
         "should": "*"
       }
     },
+    "@types/source-map-support": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.4.tgz",
+      "integrity": "sha512-9zGujX1sOPg32XLyfgEB/0G9ZnrjthL/Iv1ZfuAjj8LEilHZEpQSQs1scpRXPhHzGYgWiLz9ldF1cI8JhL+yMw==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.0"
+      }
+    },
     "@types/tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -1974,6 +2009,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "chalk": {
@@ -2248,9 +2289,9 @@
       "dev": true
     },
     "forgo": {
-      "version": "4.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-4.0.0-alpha.0.tgz",
-      "integrity": "sha512-D8H+ise8kS3vHWZBJRnlCIEBhC0GypT2cy+1Mf2eyuF6Jo4qxyAPw85cwdVQOosADP16UzEQjzATLb4depAiJg==",
+      "version": "3.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.2.0-beta.0.tgz",
+      "integrity": "sha512-JSLvM3Xwa++R2Y09b9TIoPueITRoF0pLQuXTZWoTBZ/fBqVbrIxlaEOBF+q9YTQbE97Cxag0rC1CvWwcjevWoA==",
       "peer": true
     },
     "form-data": {
@@ -2818,8 +2859,17 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
     },
     "strip-json-comments": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "typescript": "^4.6.3"
       },
       "peerDependencies": {
-        "forgo": "^3.1.0"
+        "forgo": "^4.0.0-alpha.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/forgo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.1.0.tgz",
-      "integrity": "sha512-u5QZ9vnRJoIcZelwZ3kYzJ+jrbh+lvx1Ixp5+GXxE2I3/AVdgK5IeL1hGgi3rBfhlxKjcs2fqKPycOED8FT5SQ==",
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-D8H+ise8kS3vHWZBJRnlCIEBhC0GypT2cy+1Mf2eyuF6Jo4qxyAPw85cwdVQOosADP16UzEQjzATLb4depAiJg==",
       "peer": true
     },
     "node_modules/form-data": {
@@ -2248,9 +2248,9 @@
       "dev": true
     },
     "forgo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.1.0.tgz",
-      "integrity": "sha512-u5QZ9vnRJoIcZelwZ3kYzJ+jrbh+lvx1Ixp5+GXxE2I3/AVdgK5IeL1hGgi3rBfhlxKjcs2fqKPycOED8FT5SQ==",
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-D8H+ise8kS3vHWZBJRnlCIEBhC0GypT2cy+1Mf2eyuF6Jo4qxyAPw85cwdVQOosADP16UzEQjzATLb4depAiJg==",
       "peer": true
     },
     "form-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forgo-state",
-  "version": "1.2.0",
+  "version": "1.3.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "forgo-state",
-      "version": "1.2.0",
+      "version": "1.3.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^16.2.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forgo-state",
-  "version": "1.2.0",
+  "version": "2.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "forgo-state",
-      "version": "1.2.0",
+      "version": "2.0.0-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^16.2.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forgo-state",
-  "version": "1.2.0",
+  "version": "2.0.0-alpha.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forgo-state",
-  "version": "2.0.0-alpha.0",
+  "version": "1.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,17 +10,19 @@
     "url": "https://github.com/forgojs/forgo-state"
   },
   "peerDependencies": {
-    "forgo": "^4.0.0-alpha.0"
+    "forgo": "^3.2.0-alpha.0"
   },
   "devDependencies": {
     "@types/jsdom": "^16.2.14",
     "@types/mocha": "^9.1.0",
     "@types/should": "^13.0.0",
+    "@types/source-map-support": "^0.5.4",
     "esm": "^3.2.25",
     "jsdom": "^19.0.0",
     "mocha": "^9.2.2",
     "rimraf": "^3.0.2",
     "should": "^13.2.3",
+    "source-map-support": "^0.5.21",
     "typescript": "^4.6.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/forgojs/forgo-state"
   },
   "peerDependencies": {
-    "forgo": "^3.1.0"
+    "forgo": "^4.0.0-alpha.0"
   },
   "devDependencies": {
     "@types/jsdom": "^16.2.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forgo-state",
-  "version": "1.2.0",
+  "version": "1.3.0-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,11 @@
 
   - Users create JS proxies using the defineState() function.
   - They bind this state (the proxy object) to various components via bindToStates() and bindToStateProps() functions.
-  - Since the proxy let's us capture changes to itself, we trigger component rerenders (on bound components) when that happens.
+  - Since the proxy lets us capture changes to itself, we trigger component rerenders (on bound components) when that happens.
 */
 
 import {
-  ForgoRenderArgs,
-  ForgoComponent,
+  Component,
   ForgoElementProps,
   rerender,
   getForgoState,
@@ -16,127 +15,127 @@ import {
   NodeAttachedState,
 } from "forgo";
 
-type StateBoundComponentInfo<TProps extends ForgoElementProps> = {
-  component: ForgoComponent<TProps>;
-  args: ForgoRenderArgs;
-};
+interface StateBoundComponentInfo {
+  component: Component;
+}
 
-type PropertyBoundComponentInfo<TState, TProps extends ForgoElementProps> = {
+interface PropertyBoundComponentInfo<TState> extends StateBoundComponentInfo {
   propGetter: (state: TState) => any[];
-} & StateBoundComponentInfo<TProps>;
+}
 
-const stateToComponentsMap: Map<any, StateBoundComponentInfo<any>[]> =
-  new Map();
+const stateToComponentsMap: Map<any, StateBoundComponentInfo[]> = new Map();
 
 export function defineState<TState extends Record<string, any>>(
   state: TState
 ): TState {
   const handlers = {
     set(target: TState, prop: string & keyof TState, value: any) {
-      const entries = stateToComponentsMap.get(proxy);
+      const entries = stateToComponentsMap.get(proxy) ?? [];
 
-      // if bound to the state directly, add for updation on any state change.
-      const stateBoundComponentArgs: ForgoRenderArgs[] = entries
-        ? entries
-            .filter(
-              (x) => !(x as PropertyBoundComponentInfo<TState, any>).propGetter
-            )
-            .map((x) => x.args)
-        : [];
+      // If bound to the state directly, mark for update on any state change
+      const stateBoundComponents: StateBoundComponentInfo[] = entries.filter(
+        (x) => !(x as PropertyBoundComponentInfo<TState>).propGetter
+      );
 
-      const propBoundComponents = entries
-        ? entries.filter(
-            (x) => (x as PropertyBoundComponentInfo<TState, any>).propGetter
-          )
-        : [];
+      const propBoundComponents = entries.filter(
+        (x) => (x as PropertyBoundComponentInfo<TState>).propGetter
+      );
 
       // Get the props before update
-      let propBoundComponentArgs = propBoundComponents.map((x) => ({
-        args: x.args,
-        props: (x as PropertyBoundComponentInfo<TState, any>).propGetter(
-          target
-        ),
+      const propBoundComponentProps = propBoundComponents.map((x) => ({
+        component: x.component,
+        props: (x as PropertyBoundComponentInfo<TState>).propGetter(target),
       }));
 
       target[prop] = value;
 
       // Get the props after update
-      let updatedProps = propBoundComponents.map((x) => ({
-        args: x.args,
-        props: (x as PropertyBoundComponentInfo<TState, any>).propGetter(
-          target
-        ),
+      const propBoundComponentPropsUpdated = propBoundComponents.map((x) => ({
+        component: x.component,
+        props: (x as PropertyBoundComponentInfo<TState>).propGetter(target),
       }));
 
       // State bound components (a) need to be rerendered anyway.
       // Prop bound components (b) are rendendered if changed.
       // So concat (a) and (b)
-      const argsListToUpdate = stateBoundComponentArgs.concat(
-        propBoundComponentArgs
-          .filter((oldProp, i) =>
-            oldProp.props.some((p, j) => p !== updatedProps[i].props[j])
-          )
-          .map((x) => x.args)
-      );
+      const componentsToUpdate = stateBoundComponents
+        .concat(
+          propBoundComponentProps
+            .filter((oldProp, i) =>
+              oldProp.props.some(
+                (p, j) => p !== propBoundComponentPropsUpdated[i].props[j]
+              )
+            )
+            .map((x) => x)
+        )
+        .map((x) => x.component);
 
-      // concat latest updates with pending updates.
+      // Concat latest updates with pending updates.
       const argsToUpdatePlusPendingArgs = Array.from(
-        new Set([
-          ...Array.from(argsToRenderInTheNextCycle),
-          ...argsListToUpdate,
+        new Set<Component>([
+          ...Array.from(componentsToRenderInTheNextCycle),
+          ...componentsToUpdate,
         ])
       );
 
       const componentStatesAndArgs: [
         NodeAttachedComponentState<any>,
-        ForgoRenderArgs
-      ][] = argsToUpdatePlusPendingArgs.map((x) => {
-        const state = getForgoState(x.element.node as ChildNode);
+        Component
+      ][] = argsToUpdatePlusPendingArgs.map((component) => {
+        const state = getForgoState(
+          component.__internal.element.node as ChildNode
+        );
         if (!state) {
           throw new Error("Missing state on node.");
         } else {
-          return [state.components[x.element.componentIndex], x];
+          return [
+            state.components[component.__internal.element.componentIndex],
+            component,
+          ];
         }
       });
 
       // If a parent component is already rerendering,
       // don't queue the child rerender.
-      const componentsToUpdate = componentStatesAndArgs.filter((item) => {
-        const [componentState, args] = item;
+      const dedupedComponentsToUpdate = componentStatesAndArgs.filter(
+        (item) => {
+          const [componentState, component] = item;
 
-        let node: ChildNode | null = args.element.node as ChildNode;
-        let state: NodeAttachedState | undefined = getForgoState(node);
-        let parentStates = (state as NodeAttachedState).components.slice(
-          0,
-          args.element.componentIndex
-        );
-        while (node && state) {
-          if (
-            parentStates.some((x) =>
-              componentStatesAndArgs.some(
-                ([compStateInArray]) =>
-                  compStateInArray.component === x.component
+          let node: ChildNode | null = component.__internal.element
+            .node as ChildNode;
+          let state: NodeAttachedState | undefined = getForgoState(node);
+          let parentStates = (state as NodeAttachedState).components.slice(
+            0,
+            component.__internal.element.componentIndex
+          );
+          while (node && state) {
+            if (
+              parentStates.some((x) =>
+                componentStatesAndArgs.some(
+                  ([compStateInArray]) =>
+                    compStateInArray.component === x.component
+                )
               )
-            )
-          ) {
-            return false;
-          }
-          node = node.parentElement;
-          if (node) {
-            state = getForgoState(node);
-            if (state) {
-              parentStates = state.components.filter(
-                (x) => x !== componentState
-              );
+            ) {
+              return false;
+            }
+            node = node.parentElement;
+            if (node) {
+              state = getForgoState(node);
+              if (state) {
+                parentStates = state.components.filter(
+                  (x) => x !== componentState
+                );
+              }
             }
           }
+          return true;
         }
-        return true;
-      });
+      );
 
-      for (const [, args] of componentsToUpdate) {
-        argsToRenderInTheNextCycle.add(args);
-      }
+      dedupedComponentsToUpdate.forEach(([, component]) =>
+        componentsToRenderInTheNextCycle.add(component)
+      );
 
       setTimeout(() => {
         doRender();
@@ -154,88 +153,77 @@ export function defineState<TState extends Record<string, any>>(
 // We make this a Set because if rendering a component triggers another
 // forgo-state update we want to be sure we still finish updating everything we
 // had queued, plus everything the subrender enqueues
-const argsToRenderInTheNextCycle = new Set<ForgoRenderArgs>();
+const componentsToRenderInTheNextCycle = new Set<Component>();
 
 function doRender() {
-  if (argsToRenderInTheNextCycle.size > 0) {
-    for (const args of argsToRenderInTheNextCycle) {
-      if (args.element.node && args.element.node.isConnected) {
+  if (componentsToRenderInTheNextCycle.size > 0) {
+    for (const component of componentsToRenderInTheNextCycle) {
+      if (
+        component.__internal.element.node &&
+        component.__internal.element.node.isConnected
+      ) {
         // Dequeue the component before the render, so that if the component
         // triggers more renders of itself they don't get no-op'd
-        argsToRenderInTheNextCycle.delete(args);
+        componentsToRenderInTheNextCycle.delete(component);
 
-        rerender(args.element);
+        rerender(component.__internal.element);
       }
     }
   }
 }
 
-export function bindToStates<TState, TProps extends ForgoElementProps>(
+export function bindToStates<TState>(
   states: TState[],
-  component: ForgoComponent<TProps>
-): ForgoComponent<TProps> {
-  return bindToStateProps(
+  component: Component<any>
+): void {
+  bindToStateProps(
     states.map((state) => [state, undefined]),
     component
   );
 }
 
-export function bindToStateProps<TState, TProps extends ForgoElementProps>(
+export function bindToStateProps<TState>(
   stateBindings: [state: TState, propGetter?: (state: TState) => any[]][],
-  component: ForgoComponent<TProps>
-): ForgoComponent<TProps> {
-  const wrappedComponent = {
-    ...component,
-    mount(props: TProps, args: ForgoRenderArgs) {
-      for (const [state, propGetter] of stateBindings) {
-        let entries = stateToComponentsMap.get(state);
+  component: Component<any>
+): void {
+  component.addEventListener("mount", () => {
+    for (const [state, propGetter] of stateBindings) {
+      let entries = stateToComponentsMap.get(state);
 
-        if (!entries) {
-          entries = [];
-          stateToComponentsMap.set(state, entries);
-        }
-
-        if (propGetter) {
-          const newEntry: PropertyBoundComponentInfo<TState, TProps> = {
-            component: wrappedComponent,
-            propGetter,
-            args,
-          };
-
-          entries.push(newEntry);
-        } else {
-          const newEntry: StateBoundComponentInfo<TProps> = {
-            component: wrappedComponent,
-            args,
-          };
-
-          entries.push(newEntry);
-        }
+      if (!entries) {
+        entries = [];
+        stateToComponentsMap.set(state, entries);
       }
 
-      if (component.mount) {
-        component.mount(props, args);
-      }
-    },
-    unmount(props: TProps, args: ForgoRenderArgs) {
-      for (const [state] of stateBindings) {
-        let entry = stateToComponentsMap.get(state);
+      if (propGetter) {
+        const newEntry: PropertyBoundComponentInfo<TState> = {
+          component,
+          propGetter,
+        };
 
-        if (entry) {
-          stateToComponentsMap.set(
-            state,
-            entry.filter((x) => x.component !== wrappedComponent)
-          );
-        } else {
-          throw new Error("Component entry missing in state map.");
-        }
-      }
+        entries.push(newEntry);
+      } else {
+        const newEntry: StateBoundComponentInfo = {
+          component,
+        };
 
-      if (component.unmount) {
-        component.unmount(props, args);
+        entries.push(newEntry);
       }
-    },
-  };
+    }
+  });
 
-  return wrappedComponent;
+  component.addEventListener("unmount", () => {
+    for (const [state] of stateBindings) {
+      let entry = stateToComponentsMap.get(state);
+
+      if (entry) {
+        stateToComponentsMap.set(
+          state,
+          entry.filter((x) => x.component !== component)
+        );
+      } else {
+        throw new Error("Component entry missing in state map.");
+      }
+    }
+  });
 }

--- a/src/test/batchesUpdates/index.ts
+++ b/src/test/batchesUpdates/index.ts
@@ -11,13 +11,7 @@ export default function () {
     });
     const window = dom.window;
 
-    run(dom);
-
-    await new Promise<void>((resolve) => {
-      window.addEventListener("load", () => {
-        resolve();
-      });
-    });
+    await run(dom);
 
     window.document.body.innerHTML.should.containEql(
       "There are no messages for unknown."
@@ -34,8 +28,11 @@ export default function () {
 
     window.renderCounter.should.equal(2);
 
-    window.document.body.innerHTML.should.containEql(
-      "<div><p>Messages for boom</p><ul><li>hello</li><li>world</li></ul></div>"
+    should.equal(
+      window.document.body.innerHTML.includes(
+        "<div><p>Messages for boom</p><ul><li>hello</li><li>world</li></ul></div>"
+      ),
+      true
     );
   });
 }

--- a/src/test/batchesUpdates/script.tsx
+++ b/src/test/batchesUpdates/script.tsx
@@ -4,7 +4,7 @@ import { mount, setCustomEnv, Component } from "forgo";
 import { bindToStates, defineState } from "../../index.js";
 import promiseSignal from "../promiseSignal.js";
 
-import type { ForgoComponentCtor } from "forgo";
+import type { ForgoNewComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: HTMLDocument;
@@ -21,7 +21,7 @@ const state: State = defineState({
 
 const firstPromise = promiseSignal();
 
-const MessageBox: ForgoComponentCtor = () => {
+const MessageBox: ForgoNewComponentCtor = () => {
   const component = new Component({
     render() {
       window.renderCounter++;
@@ -50,7 +50,7 @@ const MessageBox: ForgoComponentCtor = () => {
   return component;
 };
 
-export function run(dom: JSDOM) {
+export async function run(dom: JSDOM) {
   window = dom.window;
   document = window.document;
   window.myAppState = state;
@@ -58,7 +58,14 @@ export function run(dom: JSDOM) {
   window.firstPromise = firstPromise;
   setCustomEnv({ window, document });
 
-  window.addEventListener("load", () => {
-    mount(<MessageBox />, document.getElementById("root"));
+  return new Promise((resolve, reject) => {
+    window.addEventListener("load", () => {
+      try {
+        mount(<MessageBox />, document.getElementById("root"));
+        resolve(undefined);
+      } catch (ex) {
+        reject(ex);
+      }
+    });
   });
 }

--- a/src/test/batchesUpdates/script.tsx
+++ b/src/test/batchesUpdates/script.tsx
@@ -1,8 +1,10 @@
 import * as forgo from "forgo";
 import { DOMWindow, JSDOM } from "jsdom";
-import { mount, ForgoRenderArgs, setCustomEnv } from "forgo";
+import { mount, setCustomEnv, Component } from "forgo";
 import { bindToStates, defineState } from "../../index.js";
 import promiseSignal from "../promiseSignal.js";
+
+import type { ForgoComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: HTMLDocument;
@@ -19,9 +21,9 @@ const state: State = defineState({
 
 const firstPromise = promiseSignal();
 
-function MessageBox() {
-  const component = {
-    render(props: any, args: ForgoRenderArgs) {
+const MessageBox: ForgoComponentCtor = () => {
+  const component = new Component({
+    render() {
       window.renderCounter++;
       if (window.renderCounter === 2) {
         firstPromise.resolve();
@@ -43,9 +45,10 @@ function MessageBox() {
         </div>
       );
     },
-  };
-  return bindToStates([state], component);
-}
+  });
+  bindToStates([state], component);
+  return component;
+};
 
 export function run(dom: JSDOM) {
   window = dom.window;

--- a/src/test/bindToStateProps/index.ts
+++ b/src/test/bindToStateProps/index.ts
@@ -11,13 +11,7 @@ export default function () {
     });
     const window = dom.window;
 
-    run(dom);
-
-    await new Promise<void>((resolve) => {
-      window.addEventListener("load", () => {
-        resolve();
-      });
-    });
+    await run(dom);
 
     window.document.body.innerHTML.should.containEql(
       "<p>There are no messages for unknown.</p>"

--- a/src/test/bindToStateProps/script.tsx
+++ b/src/test/bindToStateProps/script.tsx
@@ -1,8 +1,10 @@
 import * as forgo from "forgo";
 import { DOMWindow, JSDOM } from "jsdom";
-import { mount, ForgoRenderArgs, setCustomEnv } from "forgo";
+import { mount, setCustomEnv, Component } from "forgo";
 import { defineState, bindToStateProps } from "../../index.js";
 import promiseSignal from "../promiseSignal.js";
+
+import type { ForgoComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: HTMLDocument;
@@ -20,9 +22,9 @@ const state: State = defineState({
 
 let renderCounter = 0;
 
-function MessageBox() {
-  const component = {
-    render(props: any, args: ForgoRenderArgs) {
+const MessageBox: ForgoComponentCtor = () => {
+  const component = new Component({
+    render() {
       if (renderCounter === 1) {
         firstPromise.resolve();
       }
@@ -37,9 +39,10 @@ function MessageBox() {
         </div>
       );
     },
-  };
-  return bindToStateProps([[state, (x) => [x.messages]]], component);
-}
+  });
+  bindToStateProps([[state, (x) => [x.messages]]], component);
+  return component;
+};
 
 export function run(dom: JSDOM) {
   window = dom.window;

--- a/src/test/bindToStateProps/script.tsx
+++ b/src/test/bindToStateProps/script.tsx
@@ -4,7 +4,7 @@ import { mount, setCustomEnv, Component } from "forgo";
 import { defineState, bindToStateProps } from "../../index.js";
 import promiseSignal from "../promiseSignal.js";
 
-import type { ForgoComponentCtor } from "forgo";
+import type { ForgoNewComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: HTMLDocument;
@@ -22,7 +22,7 @@ const state: State = defineState({
 
 let renderCounter = 0;
 
-const MessageBox: ForgoComponentCtor = () => {
+const MessageBox: ForgoNewComponentCtor = () => {
   const component = new Component({
     render() {
       if (renderCounter === 1) {
@@ -44,14 +44,21 @@ const MessageBox: ForgoComponentCtor = () => {
   return component;
 };
 
-export function run(dom: JSDOM) {
+export async function run(dom: JSDOM) {
   window = dom.window;
   document = window.document;
   window.myAppState = state;
   window.firstPromise = firstPromise;
   setCustomEnv({ window, document });
 
-  window.addEventListener("load", () => {
-    mount(<MessageBox />, document.getElementById("root"));
+  return new Promise((resolve, reject) => {
+    window.addEventListener("load", () => {
+      try {
+        mount(<MessageBox />, document.getElementById("root"));
+        resolve(undefined);
+      } catch (ex) {
+        reject(ex);
+      }
+    });
   });
 }

--- a/src/test/bindToStates/index.ts
+++ b/src/test/bindToStates/index.ts
@@ -11,15 +11,11 @@ export default function () {
     });
     const window = dom.window;
 
-    run(dom);
+    await run(dom);
 
-    await new Promise<void>((resolve) => {
-      window.addEventListener("load", () => {
-        resolve();
-      });
-    });
-
-    window.document.body.innerHTML.should.containEql("There are no messages for unknown.");
+    window.document.body.innerHTML.should.containEql(
+      "There are no messages for unknown."
+    );
 
     window.myAppState.account = "boom";
 

--- a/src/test/bindToStates/script.tsx
+++ b/src/test/bindToStates/script.tsx
@@ -4,7 +4,7 @@ import { mount, setCustomEnv, Component } from "forgo";
 import { bindToStates, defineState } from "../../index.js";
 import promiseSignal from "../promiseSignal.js";
 
-import type { ForgoComponentCtor } from "forgo";
+import type { ForgoNewComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: HTMLDocument;
@@ -24,7 +24,7 @@ const state: State = defineState({
 
 let renderCounter = 0;
 
-const MessageBox: ForgoComponentCtor = () => {
+const MessageBox: ForgoNewComponentCtor = () => {
   const component = new Component({
     render() {
       if (renderCounter === 1) {
@@ -48,7 +48,7 @@ const MessageBox: ForgoComponentCtor = () => {
   return component;
 };
 
-export function run(dom: JSDOM) {
+export async function run(dom: JSDOM) {
   window = dom.window;
   document = window.document;
   window.myAppState = state;
@@ -56,7 +56,14 @@ export function run(dom: JSDOM) {
   window.secondPromise = secondPromise;
   setCustomEnv({ window, document });
 
-  window.addEventListener("load", () => {
-    mount(<MessageBox />, document.getElementById("root"));
+  return new Promise((resolve, reject) => {
+    window.addEventListener("load", () => {
+      try {
+        mount(<MessageBox />, document.getElementById("root"));
+        resolve(undefined);
+      } catch (ex) {
+        reject(ex);
+      }
+    });
   });
 }

--- a/src/test/bindToStates/script.tsx
+++ b/src/test/bindToStates/script.tsx
@@ -1,8 +1,10 @@
 import * as forgo from "forgo";
 import { DOMWindow, JSDOM } from "jsdom";
-import { mount, ForgoRenderArgs, setCustomEnv } from "forgo";
+import { mount, setCustomEnv, Component } from "forgo";
 import { bindToStates, defineState } from "../../index.js";
 import promiseSignal from "../promiseSignal.js";
+
+import type { ForgoComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: HTMLDocument;
@@ -22,9 +24,9 @@ const state: State = defineState({
 
 let renderCounter = 0;
 
-function MessageBox() {
-  const component = {
-    render(props: any, args: ForgoRenderArgs) {
+const MessageBox: ForgoComponentCtor = () => {
+  const component = new Component({
+    render() {
       if (renderCounter === 1) {
         firstPromise.resolve();
       } else if (renderCounter === 2) {
@@ -41,9 +43,10 @@ function MessageBox() {
         </div>
       );
     },
-  };
-  return bindToStates([state], component);
-}
+  });
+  bindToStates([state], component);
+  return component;
+};
 
 export function run(dom: JSDOM) {
   window = dom.window;

--- a/src/test/descendantMustNotRerender/index.ts
+++ b/src/test/descendantMustNotRerender/index.ts
@@ -11,13 +11,7 @@ export default function () {
     });
     const window = dom.window;
 
-    run(dom);
-
-    await new Promise<void>((resolve) => {
-      window.addEventListener("load", () => {
-        resolve();
-      });
-    });
+    await run(dom);
 
     window.myAppState.account = "boom";
 

--- a/src/test/descendantMustNotRerender/script.tsx
+++ b/src/test/descendantMustNotRerender/script.tsx
@@ -4,7 +4,7 @@ import { mount, setCustomEnv, Component } from "forgo";
 import { bindToStates, defineState } from "../../index.js";
 import promiseSignal from "../promiseSignal.js";
 
-import type { ForgoComponentCtor } from "forgo";
+import type { ForgoNewComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: HTMLDocument;
@@ -21,7 +21,7 @@ const state: State = defineState({
   account: "unknown",
 });
 
-const Parent: ForgoComponentCtor = () => {
+const Parent: ForgoNewComponentCtor = () => {
   const component = new Component({
     render() {
       if (window.parentCounter === 1) {
@@ -40,7 +40,7 @@ const Parent: ForgoComponentCtor = () => {
   return component;
 };
 
-const Child: ForgoComponentCtor = () => {
+const Child: ForgoNewComponentCtor = () => {
   const component = new Component({
     render() {
       window.childCounter++;
@@ -55,7 +55,7 @@ const Child: ForgoComponentCtor = () => {
   return component;
 };
 
-export function run(dom: JSDOM) {
+export async function run(dom: JSDOM) {
   window = dom.window;
   document = window.document;
   window.myAppState = state;
@@ -65,7 +65,14 @@ export function run(dom: JSDOM) {
 
   setCustomEnv({ window, document });
 
-  window.addEventListener("load", () => {
-    mount(<Parent />, document.getElementById("root"));
+  return new Promise((resolve, reject) => {
+    window.addEventListener("load", () => {
+      try {
+        mount(<Parent />, document.getElementById("root"));
+        resolve(undefined);
+      } catch (ex) {
+        reject(ex);
+      }
+    });
   });
 }

--- a/src/test/descendantMustNotRerender/script.tsx
+++ b/src/test/descendantMustNotRerender/script.tsx
@@ -1,8 +1,10 @@
 import * as forgo from "forgo";
 import { DOMWindow, JSDOM } from "jsdom";
-import { mount, ForgoRenderArgs, setCustomEnv } from "forgo";
+import { mount, setCustomEnv, Component } from "forgo";
 import { bindToStates, defineState } from "../../index.js";
 import promiseSignal from "../promiseSignal.js";
+
+import type { ForgoComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: HTMLDocument;
@@ -19,9 +21,9 @@ const state: State = defineState({
   account: "unknown",
 });
 
-function Parent() {
-  const component = {
-    render(props: any, args: ForgoRenderArgs) {
+const Parent: ForgoComponentCtor = () => {
+  const component = new Component({
+    render() {
       if (window.parentCounter === 1) {
         firstPromise.resolve();
       }
@@ -33,13 +35,14 @@ function Parent() {
         </div>
       );
     },
-  };
-  return bindToStates([state], component);
-}
+  });
+  bindToStates([state], component);
+  return component;
+};
 
-function Child() {
-  const component = {
-    render(props: any, args: ForgoRenderArgs) {
+const Child: ForgoComponentCtor = () => {
+  const component = new Component({
+    render() {
       window.childCounter++;
       return (
         <div>
@@ -47,9 +50,10 @@ function Child() {
         </div>
       );
     },
-  };
-  return bindToStates([state], component);
-}
+  });
+  bindToStates([state], component);
+  return component;
+};
 
 export function run(dom: JSDOM) {
   window = dom.window;
@@ -58,7 +62,7 @@ export function run(dom: JSDOM) {
   window.firstPromise = firstPromise;
   window.parentCounter = 0;
   window.childCounter = 0;
-  
+
   setCustomEnv({ window, document });
 
   window.addEventListener("load", () => {

--- a/src/test/dontRenderDisconnectedNodes/index.ts
+++ b/src/test/dontRenderDisconnectedNodes/index.ts
@@ -1,4 +1,6 @@
 import { JSDOM } from "jsdom";
+import should from "should";
+
 import htmlFile from "../htmlFile.js";
 import { addNewMessage, renderAgain, run } from "./script.js";
 
@@ -10,17 +12,14 @@ export default function () {
     });
     const window = dom.window;
 
-    run(dom);
-
-    await new Promise<void>((resolve) => {
-      window.addEventListener("load", () => {
-        resolve();
-      });
-    });
+    await run(dom);
 
     addNewMessage();
     renderAgain();
 
-    window.document.body.innerHTML.trim().should.containEql(`<div id="root"></div>`)
+    should.equal(
+      window.document.body.innerHTML.trim(),
+      '<div id="root"><!--null component render--></div>'
+    );
   });
 }

--- a/src/test/dontRenderDisconnectedNodes/script.tsx
+++ b/src/test/dontRenderDisconnectedNodes/script.tsx
@@ -3,7 +3,7 @@ import { DOMWindow, JSDOM } from "jsdom";
 import { mount, setCustomEnv, Component } from "forgo";
 import { bindToStates, defineState } from "../../index.js";
 
-import type { ForgoComponentCtor } from "forgo";
+import type { ForgoNewComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: Document;
@@ -28,7 +28,7 @@ export function renderAgain() {
   component.update();
 }
 
-const Parent: ForgoComponentCtor = () => {
+const Parent: ForgoNewComponentCtor = () => {
   component = new Component({
     render() {
       return counter === 0 ? <MessageBox /> : null;
@@ -37,7 +37,7 @@ const Parent: ForgoComponentCtor = () => {
   return component;
 };
 
-const MessageBox: ForgoComponentCtor = () => {
+const MessageBox: ForgoNewComponentCtor = () => {
   const component = new Component({
     render() {
       return <p>You have {state.messageCount} messages.</p>;
@@ -47,12 +47,19 @@ const MessageBox: ForgoComponentCtor = () => {
   return component;
 };
 
-export function run(dom: JSDOM) {
+export async function run(dom: JSDOM) {
   window = dom.window;
   document = window.document;
   setCustomEnv({ window, document });
 
-  window.addEventListener("load", () => {
-    mount(<Parent />, document.getElementById("root"));
+  return new Promise((resolve, reject) => {
+    window.addEventListener("load", () => {
+      try {
+        mount(<Parent />, document.getElementById("root"));
+        resolve(undefined);
+      } catch (ex) {
+        reject(ex);
+      }
+    });
   });
 }

--- a/src/test/dontRenderDisconnectedNodes/script.tsx
+++ b/src/test/dontRenderDisconnectedNodes/script.tsx
@@ -1,7 +1,9 @@
 import * as forgo from "forgo";
 import { DOMWindow, JSDOM } from "jsdom";
-import { mount, ForgoRenderArgs, setCustomEnv } from "forgo";
+import { mount, setCustomEnv, Component } from "forgo";
 import { bindToStates, defineState } from "../../index.js";
+
+import type { ForgoComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: Document;
@@ -20,29 +22,30 @@ export function addNewMessage() {
 
 let counter = 0;
 
-let renderArgs: ForgoRenderArgs;
+let component: Component;
 export function renderAgain() {
   counter++;
-  renderArgs.update();
+  component.update();
 }
 
-function Parent() {
-  return {
-    render(props: {}, args: ForgoRenderArgs) {
-      renderArgs = args;
+const Parent: ForgoComponentCtor = () => {
+  component = new Component({
+    render() {
       return counter === 0 ? <MessageBox /> : null;
     },
-  };
-}
+  });
+  return component;
+};
 
-function MessageBox() {
-  const component = {
-    render(props: any, args: ForgoRenderArgs) {
+const MessageBox: ForgoComponentCtor = () => {
+  const component = new Component({
+    render() {
       return <p>You have {state.messageCount} messages.</p>;
     },
-  };
-  return bindToStates([state], component);
-}
+  });
+  bindToStates([state], component);
+  return component;
+};
 
 export function run(dom: JSDOM) {
   window = dom.window;

--- a/src/test/fragments/index.ts
+++ b/src/test/fragments/index.ts
@@ -12,13 +12,7 @@ export default function () {
       });
       const window = dom.window;
 
-      run(dom);
-
-      await new Promise<void>((resolve) => {
-        window.addEventListener("load", () => {
-          resolve();
-        });
-      });
+      await run(dom);
 
       window.myAppState.totals = 200;
       await window.firstPromise.promise;

--- a/src/test/fragments/script.tsx
+++ b/src/test/fragments/script.tsx
@@ -4,22 +4,18 @@ import { mount, setCustomEnv, Component } from "forgo";
 import { bindToStates, defineState } from "../../index.js";
 import promiseSignal from "../promiseSignal.js";
 
-import type { ForgoComponentCtor } from "forgo";
+import type { ForgoNewComponentCtor } from "forgo";
 
 let window: DOMWindow;
-let document: HTMLDocument;
+let document: Document;
 
 const firstPromise = promiseSignal();
 
-type State = {
-  totals: number;
-};
-
-const state: State = defineState({
+const state = defineState({
   totals: 100,
 });
 
-const Parent: ForgoComponentCtor = () => {
+const Parent: ForgoNewComponentCtor = () => {
   const component = new Component({
     render() {
       if (window.parentCounter === 1) {
@@ -39,7 +35,7 @@ const Parent: ForgoComponentCtor = () => {
   return component;
 };
 
-const Child: ForgoComponentCtor = () => {
+const Child: ForgoNewComponentCtor = () => {
   const component = new Component({
     render() {
       window.childCounter++;
@@ -54,7 +50,7 @@ const Child: ForgoComponentCtor = () => {
   return component;
 };
 
-export function run(dom: JSDOM) {
+export async function run(dom: JSDOM) {
   window = dom.window;
   document = window.document;
   window.myAppState = state;
@@ -64,7 +60,14 @@ export function run(dom: JSDOM) {
 
   setCustomEnv({ window, document });
 
-  window.addEventListener("load", () => {
-    mount(<Parent />, document.getElementById("root"));
+  return new Promise((resolve, reject) => {
+    window.addEventListener("load", () => {
+      try {
+        mount(<Parent />, document.getElementById("root"));
+        resolve(undefined);
+      } catch (ex) {
+        reject(ex);
+      }
+    });
   });
 }

--- a/src/test/fragments/script.tsx
+++ b/src/test/fragments/script.tsx
@@ -1,8 +1,10 @@
 import * as forgo from "forgo";
 import { DOMWindow, JSDOM } from "jsdom";
-import { mount, ForgoRenderArgs, setCustomEnv } from "forgo";
+import { mount, setCustomEnv, Component } from "forgo";
 import { bindToStates, defineState } from "../../index.js";
 import promiseSignal from "../promiseSignal.js";
+
+import type { ForgoComponentCtor } from "forgo";
 
 let window: DOMWindow;
 let document: HTMLDocument;
@@ -17,9 +19,9 @@ const state: State = defineState({
   totals: 100,
 });
 
-function Parent() {
-  const component = {
-    render(props: any, args: ForgoRenderArgs) {
+const Parent: ForgoComponentCtor = () => {
+  const component = new Component({
+    render() {
       if (window.parentCounter === 1) {
         firstPromise.resolve();
       }
@@ -32,13 +34,14 @@ function Parent() {
         </>
       );
     },
-  };
-  return bindToStates([state], component);
-}
+  });
+  bindToStates([state], component);
+  return component;
+};
 
-function Child() {
-  const component = {
-    render(props: any, args: ForgoRenderArgs) {
+const Child: ForgoComponentCtor = () => {
+  const component = new Component({
+    render() {
       window.childCounter++;
       return (
         <div>
@@ -46,9 +49,10 @@ function Child() {
         </div>
       );
     },
-  };
-  return bindToStates([state], component);
-}
+  });
+  bindToStates([state], component);
+  return component;
+};
 
 export function run(dom: JSDOM) {
   window = dom.window;

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1,3 +1,6 @@
+import sourceMapSupport from "source-map-support";
+sourceMapSupport.install();
+
 import defineState from "./defineState/index.js";
 import bindToStates from "./bindToStates/index.js";
 import bindToStateProps from "./bindToStateProps/index.js";


### PR DESCRIPTION
This updates forgo-state for the new component API. It wraps incoming legacy components, so it shouldn't be a breaking change (aside from now depending on `forgo@3.2.0-beta.0` and higher). Not sure if that's enough to do a major version bump, your call.

I fixed a bug where we tried to render components after they'd unmounted. This didn't manifest until the last few Forgo changes merged (worked in `forgo@4.0.0-alpha.0`, broke in `forgo@3.2.0-beta.0`). I'm not really sure which specific change caused the bug, but I think it was one of the two PRs that affected when unmounts happen. But I'm not sure it's a forgo bug, since forgo-state was clearly in the wrong to only clean up its bookkeeping if a component was still mounted.

I also made a minor optimization to bookkeeping cleanup, which should help when a bazillion components depend on one state.

I restructured the tests slightly while debugging the aforementioned bug. At some point it'd be nice to get these using the `componentRunner`.